### PR TITLE
API Error Message Handling

### DIFF
--- a/cdapython/explore.py
+++ b/cdapython/explore.py
@@ -590,7 +590,7 @@ def columns(
 
         except ApiException as e:
             
-            if e.body is not None:
+            try:
                 
                 # Ordinarily, this exception represents a structured complaint
                 # from the API service that something went wrong. In this case,
@@ -600,7 +600,7 @@ def columns(
 
                 error_message = json.loads( e.body )['message']
 
-            else:
+            except:
                 
                 # Unfortunately, if something goes wrong at the level of the
                 # HTTP service on which the API relies -- that is, when we
@@ -1417,7 +1417,7 @@ def column_values(
 
         except ApiException as e:
             
-            if e.body is not None:
+            try:
                 
                 # Ordinarily, this exception represents a structured complaint
                 # from the API service that something went wrong. In this case,
@@ -1427,7 +1427,7 @@ def column_values(
 
                 error_message = json.loads( e.body )['message']
 
-            else:
+            except:
                 
                 # Unfortunately, if something goes wrong at the level of the
                 # HTTP service on which the API relies -- that is, when we
@@ -1534,7 +1534,7 @@ def column_values(
 
             except ApiException as e:
                 
-                if e.body is not None:
+                try:
                     
                     # Ordinarily, this exception represents a structured complaint
                     # from the API service that something went wrong. In this case,
@@ -1544,7 +1544,7 @@ def column_values(
 
                     error_message = json.loads( e.body )['message']
 
-                else:
+                except:
                     
                     # Unfortunately, if something goes wrong at the level of the
                     # HTTP service on which the API relies -- that is, when we
@@ -3450,7 +3450,7 @@ def summary_counts(
 
         except ApiException as e:
             
-            if e.body is not None:
+            try:
                 
                 # Ordinarily, this exception represents a structured complaint
                 # from the API service that something went wrong. In this case,
@@ -3460,7 +3460,7 @@ def summary_counts(
 
                 error_message = json.loads( e.body )['message']
 
-            else:
+            except:
                 
                 # Unfortunately, if something goes wrong at the level of the
                 # HTTP service on which the API relies -- that is, when we

--- a/cdapython/fetch.py
+++ b/cdapython/fetch.py
@@ -1901,7 +1901,7 @@ def fetch_rows(
 
                 except ApiException as e:
                     
-                    if e.body is not None:
+                    try:
                         
                         # Ordinarily, this exception represents a structured complaint
                         # from the API service that something went wrong. In this case,
@@ -1911,7 +1911,7 @@ def fetch_rows(
 
                         error_message = json.loads( e.body )['message']
 
-                    else:
+                    except:
                         
                         # Unfortunately, if something goes wrong at the level of the
                         # HTTP service on which the API relies -- that is, when we
@@ -1968,7 +1968,7 @@ def fetch_rows(
 
         except ApiException as e:
             
-            if e.body is not None:
+            try:
                 
                 # Ordinarily, this exception represents a structured complaint
                 # from the API service that something went wrong. In this case,
@@ -1978,7 +1978,7 @@ def fetch_rows(
 
                 error_message = json.loads( e.body )['message']
 
-            else:
+            except:
                 
                 # Unfortunately, if something goes wrong at the level of the
                 # HTTP service on which the API relies -- that is, when we
@@ -2089,7 +2089,7 @@ def fetch_rows(
 
             except ApiException as e:
                 
-                if e.body is not None:
+                try:
                     
                     # Ordinarily, this exception represents a structured complaint
                     # from the API service that something went wrong. In this case,
@@ -2099,7 +2099,7 @@ def fetch_rows(
 
                     error_message = json.loads( e.body )['message']
 
-                else:
+                except:
                     
                     # Unfortunately, if something goes wrong at the level of the
                     # HTTP service on which the API relies -- that is, when we


### PR DESCRIPTION
Due to quirks with the current API, not all error messages return as json objects. Because of this, trying to use json.decode on the message will result in JSON DECODE ERROR. Using 'try/except' resolves this.