### PR TITLE
Fix for cases where we do a fetch_rows with just a table name. Previo…

### DIFF
--- a/cdapython/fetch.py
+++ b/cdapython/fetch.py
@@ -1312,10 +1312,11 @@ def fetch_rows(
 
     # If we're adding extra columns from some non-`table` table*, always
     # include that table's ID field, whether or not it was requested.
+    if join_table_id_field is not None:
 
-    columns_to_fetch.append( join_table_id_field )
-
-    use_only_default_columns = False
+        columns_to_fetch.append( join_table_id_field )
+        
+        use_only_default_columns = False
 
     for column_to_add in add_columns:
         


### PR DESCRIPTION
…usly we would have a run-time error bc a None type would get added to our columns_to_fetch list. Now we are reintroducing the former None check to prevent it from being added.

Fixes this fetch_rows call:
fetch_rows(table='diagnosis')
fetch_rows(table='mutation')